### PR TITLE
doc: add Terra install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ System monitoring tool with historical data service, triggers and top-like TUI
 yay -S ttop             # enables systemd.timers automatically
 ```
 
+### Fedora
+Install the [Terra repository](https://terra.fyralabs.com/)
+```bash
+sudo dnf install ttop
+```
+
 ### Static binary (x86-64)
 
 ```bash


### PR DESCRIPTION
I recently packaged ttop in Terra, a third-party Fedora repository, this will help point users there.